### PR TITLE
Bump jte version to 1.12.0 for better hot reload support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ssZ</maven.build.timestamp.format>
 
-        <jte.version>1.11.0</jte.version>
+        <jte.version>1.12.0</jte.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Would be nice to bump the spring boot demo to the latest jte version. The hot reload dev experience is a lot better with it: https://github.com/casid/jte/releases/tag/1.12.0